### PR TITLE
Add behavioral depth: callback side-effects, behavioral profile, flow precomputation

### DIFF
--- a/lib/codebase_index.rb
+++ b/lib/codebase_index.rb
@@ -38,7 +38,7 @@ module CodebaseIndex
     attr_accessor :embedding_model, :include_framework_sources, :gem_configs,
                   :vector_store, :metadata_store, :graph_store, :embedding_provider, :log_level,
                   :vector_store_options, :metadata_store_options, :embedding_options,
-                  :concurrent_extraction
+                  :concurrent_extraction, :precompute_flows
     attr_reader :max_context_tokens, :similarity_threshold, :extractors, :pretty_json
 
     def initialize
@@ -52,6 +52,7 @@ module CodebaseIndex
                        managers policies validators rails_source]
       @pretty_json = true
       @concurrent_extraction = false
+      @precompute_flows = false
     end
 
     # @return [Pathname, String] Output directory, defaulting to Rails.root/tmp/codebase_index

--- a/lib/codebase_index/extractors/behavioral_profile.rb
+++ b/lib/codebase_index/extractors/behavioral_profile.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+module CodebaseIndex
+  module Extractors
+    # BehavioralProfile introspects resolved Rails.application.config values
+    # to produce a single ExtractedUnit summarizing the app's runtime
+    # behavioral configuration.
+    #
+    # Sections extracted (each independently guarded):
+    # - Database: adapter, schema_format, belongs_to_required, has_many_inversing
+    # - Frameworks: ActionCable, ActiveStorage, ActionMailbox, ActionText, Turbo, Stimulus, SolidQueue, SolidCache
+    # - Behavior flags: api_only, eager_load, time_zone, strong params action, session store, filter params
+    # - Background processing: active_job queue_adapter
+    # - Caching: cache_store type
+    # - Email: delivery_method
+    #
+    # @example
+    #   profile = BehavioralProfile.new
+    #   unit = profile.extract
+    #   unit.metadata[:database][:adapter] #=> "postgresql"
+    #
+    class BehavioralProfile
+      # Frameworks to detect via `defined?` checks
+      FRAMEWORK_CHECKS = {
+        action_cable: 'ActionCable',
+        active_storage: 'ActiveStorage',
+        action_mailbox: 'ActionMailbox',
+        action_text: 'ActionText',
+        turbo: 'Turbo',
+        stimulus_reflex: 'StimulusReflex',
+        solid_queue: 'SolidQueue',
+        solid_cache: 'SolidCache'
+      }.freeze
+
+      # Extract a behavioral profile from the current Rails application.
+      #
+      # @return [ExtractedUnit, nil] A single configuration unit, or nil on catastrophic failure
+      def extract
+        config = Rails.application.config
+
+        profile = {
+          config_type: 'behavioral_profile',
+          rails_version: Rails.version,
+          ruby_version: RUBY_VERSION,
+          database: extract_database(config),
+          frameworks_active: extract_frameworks,
+          behavior_flags: extract_behavior_flags(config),
+          background_processing: extract_background(config),
+          caching: extract_caching(config),
+          email: extract_email(config)
+        }
+
+        build_unit(profile)
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile extraction failed: #{e.message}")
+        nil
+      end
+
+      private
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Database
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Extract database configuration from ActiveRecord.
+      #
+      # @param config [Rails::Application::Configuration]
+      # @return [Hash]
+      def extract_database(config)
+        return {} unless defined?(ActiveRecord::Base)
+
+        result = {}
+
+        if ActiveRecord::Base.respond_to?(:connection_db_config)
+          result[:adapter] = ActiveRecord::Base.connection_db_config.adapter
+        end
+
+        if config.respond_to?(:active_record)
+          ar = config.active_record
+          result[:schema_format] = ar.schema_format if ar.respond_to?(:schema_format)
+          if ar.respond_to?(:belongs_to_required_by_default)
+            result[:belongs_to_required_by_default] = ar.belongs_to_required_by_default
+          end
+          result[:has_many_inversing] = ar.has_many_inversing if ar.respond_to?(:has_many_inversing)
+        end
+
+        result
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile database section failed: #{e.message}")
+        {}
+      end
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Frameworks
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Detect which optional frameworks are loaded.
+      #
+      # @return [Hash]
+      def extract_frameworks
+        FRAMEWORK_CHECKS.transform_values do |constant_name|
+          Object.const_defined?(constant_name)
+        end
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile frameworks section failed: #{e.message}")
+        {}
+      end
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Behavior flags
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Extract behavior flags from Rails config.
+      #
+      # @param config [Rails::Application::Configuration]
+      # @return [Hash]
+      def extract_behavior_flags(config)
+        flags = {}
+
+        safe_read(config, :api_only) { |v| flags[:api_only] = v }
+        safe_read(config, :eager_load) { |v| flags[:eager_load] = v }
+        safe_read(config, :time_zone) { |v| flags[:time_zone] = v }
+        safe_read(config, :session_store) { |v| flags[:session_store] = v }
+        safe_read(config, :filter_parameters) { |v| flags[:filter_parameters] = v }
+
+        if config.respond_to?(:action_controller)
+          ac = config.action_controller
+          if ac.respond_to?(:action_on_unpermitted_parameters)
+            flags[:action_on_unpermitted_parameters] = ac.action_on_unpermitted_parameters
+          end
+        end
+
+        flags
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile behavior_flags section failed: #{e.message}")
+        {}
+      end
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Background processing
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Extract background processing configuration.
+      #
+      # @param config [Rails::Application::Configuration]
+      # @return [Hash]
+      def extract_background(config)
+        return {} unless config.respond_to?(:active_job)
+
+        aj = config.active_job
+        return {} unless aj.respond_to?(:queue_adapter)
+
+        { adapter: aj.queue_adapter }
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile background section failed: #{e.message}")
+        {}
+      end
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Caching
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Extract caching configuration.
+      #
+      # @param config [Rails::Application::Configuration]
+      # @return [Hash]
+      def extract_caching(config)
+        return {} unless config.respond_to?(:cache_store)
+
+        raw = config.cache_store
+        store = raw.is_a?(Array) ? raw.first : raw
+
+        { store: store }
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile caching section failed: #{e.message}")
+        {}
+      end
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Email
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Extract email delivery configuration.
+      #
+      # @param config [Rails::Application::Configuration]
+      # @return [Hash]
+      def extract_email(config)
+        return {} unless config.respond_to?(:action_mailer)
+
+        am = config.action_mailer
+        return {} unless am.respond_to?(:delivery_method)
+
+        { delivery_method: am.delivery_method }
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile email section failed: #{e.message}")
+        {}
+      end
+
+      # ──────────────────────────────────────────────────────────────────────
+      # Unit construction
+      # ──────────────────────────────────────────────────────────────────────
+
+      # Build the ExtractedUnit from the assembled profile hash.
+      #
+      # @param profile [Hash]
+      # @return [ExtractedUnit]
+      def build_unit(profile)
+        unit = ExtractedUnit.new(
+          type: :configuration,
+          identifier: 'BehavioralProfile',
+          file_path: Rails.root.join('config/application.rb').to_s
+        )
+
+        unit.namespace = 'behavioral_profile'
+        unit.metadata = profile
+        unit.source_code = build_narrative(profile)
+        unit.dependencies = build_dependencies(profile)
+
+        unit
+      end
+
+      # Generate a human-readable narrative summary.
+      #
+      # @param profile [Hash]
+      # @return [String]
+      def build_narrative(profile)
+        lines = []
+        lines << '# Behavioral Profile'
+        lines << "# Rails #{profile[:rails_version]} / Ruby #{profile[:ruby_version]}"
+        lines << '#'
+
+        # Database
+        db = profile[:database]
+        if db.any?
+          lines << "# Database: #{db[:adapter] || 'unknown'}"
+          lines << "#   schema_format: #{db[:schema_format]}" if db[:schema_format]
+          unless db[:belongs_to_required_by_default].nil?
+            lines << "#   belongs_to_required: #{db[:belongs_to_required_by_default]}"
+          end
+          lines << "#   has_many_inversing: #{db[:has_many_inversing]}" unless db[:has_many_inversing].nil?
+        end
+
+        # Frameworks
+        active = profile[:frameworks_active].select { |_, v| v }
+        if active.any?
+          lines << '#'
+          lines << "# Active frameworks: #{active.keys.map { |k| FRAMEWORK_CHECKS[k] || k.to_s }.join(', ')}"
+        end
+
+        # Behavior flags
+        flags = profile[:behavior_flags]
+        if flags.any?
+          lines << '#'
+          lines << '# Behavior flags:'
+          flags.each { |k, v| lines << "#   #{k}: #{v}" }
+        end
+
+        # Background
+        bg = profile[:background_processing]
+        if bg.any?
+          lines << '#'
+          lines << "# Background: #{bg[:adapter]}"
+        end
+
+        # Caching
+        cache = profile[:caching]
+        if cache.any?
+          lines << '#'
+          lines << "# Cache store: #{cache[:store]}"
+        end
+
+        # Email
+        email = profile[:email]
+        if email.any?
+          lines << '#'
+          lines << "# Email delivery: #{email[:delivery_method]}"
+        end
+
+        lines.join("\n")
+      end
+
+      # Build dependency list from detected frameworks and adapters.
+      #
+      # @param profile [Hash]
+      # @return [Array<Hash>]
+      def build_dependencies(profile)
+        deps = []
+
+        profile[:frameworks_active].each do |key, active|
+          next unless active
+
+          constant_name = FRAMEWORK_CHECKS[key] || key.to_s
+          deps << { type: :framework, target: constant_name, via: :behavioral_profile }
+        end
+
+        deps
+      end
+
+      # Safely read a config attribute if it responds to it.
+      #
+      # @param obj [Object]
+      # @param method [Symbol]
+      # @yield [value] Yields the value if available
+      def safe_read(obj, method)
+        yield obj.public_send(method) if obj.respond_to?(method)
+      end
+    end
+  end
+end

--- a/lib/codebase_index/extractors/callback_analyzer.rb
+++ b/lib/codebase_index/extractors/callback_analyzer.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'set'
+require_relative '../ast/parser'
+require_relative '../flow_analysis/operation_extractor'
+
+module CodebaseIndex
+  module Extractors
+    # Analyzes callback method bodies to detect side effects.
+    #
+    # Given a model's composite source code (with inlined concerns) and its
+    # callback metadata, this analyzer finds each callback method body and
+    # classifies its side effects: column writes, job enqueues, service calls,
+    # mailer triggers, and database reads.
+    #
+    # @example
+    #   analyzer = CallbackAnalyzer.new(
+    #     source_code: model_source,
+    #     column_names: %w[email status name]
+    #   )
+    #   enriched = analyzer.analyze(callback_hash)
+    #   enriched[:side_effects][:columns_written] #=> ["email"]
+    #
+    class CallbackAnalyzer
+      # Database query methods that indicate a read operation.
+      DB_READ_METHODS = %w[find where pluck first last].freeze
+
+      # Methods that write a single column, taking column name as first argument.
+      SINGLE_COLUMN_WRITERS = %w[update_column write_attribute].freeze
+
+      # Methods that write multiple columns via keyword arguments.
+      MULTI_COLUMN_WRITERS = %w[update_columns assign_attributes].freeze
+
+      # Async enqueue methods that indicate a job is being dispatched.
+      ASYNC_METHODS = %w[perform_later perform_async perform_in perform_at].freeze
+
+      # @param source_code [String] Composite model source (with inlined concerns)
+      # @param column_names [Array<String>] Model's database column names
+      def initialize(source_code:, column_names: [])
+        @source_code = source_code
+        @column_names = column_names.map(&:to_s)
+        @parser = Ast::Parser.new
+        @operation_extractor = FlowAnalysis::OperationExtractor.new
+        @parsed_root = safe_parse
+      end
+
+      # Analyze a single callback and enrich it with side-effect data.
+      #
+      # Finds the callback's method body in the source, scans it for
+      # side effects, and returns the original callback hash with an
+      # added :side_effects key.
+      #
+      # @param callback_hash [Hash] Callback metadata from ModelExtractor:
+      #   { type:, filter:, kind:, conditions: }
+      # @return [Hash] The callback hash with an added :side_effects key
+      def analyze(callback_hash)
+        filter = callback_hash[:filter].to_s
+        method_node = find_method_node(filter)
+
+        return callback_hash.merge(side_effects: empty_side_effects) if method_node.nil?
+
+        method_source = method_source_from_node(method_node)
+        return callback_hash.merge(side_effects: empty_side_effects) if method_source.nil?
+
+        callback_hash.merge(
+          side_effects: {
+            columns_written: detect_columns_written(method_source),
+            jobs_enqueued: detect_jobs_enqueued(method_source),
+            services_called: detect_services_called(method_source),
+            mailers_triggered: detect_mailers_triggered(method_source),
+            database_reads: detect_database_reads(method_source),
+            operations: extract_operations(method_node)
+          }
+        )
+      end
+
+      private
+
+      # Parse source code safely, returning nil on failure.
+      #
+      # @return [Ast::Node, nil]
+      def safe_parse
+        @parser.parse(@source_code)
+      rescue StandardError
+        nil
+      end
+
+      # Find a method definition node by name in the cached AST.
+      #
+      # @param method_name [String]
+      # @return [Ast::Node, nil]
+      def find_method_node(method_name)
+        return nil unless @parsed_root
+        return nil if method_name.empty? || !valid_method_name?(method_name)
+
+        @parsed_root.find_all(:def).find do |node|
+          node.method_name == method_name
+        end
+      end
+
+      # Extract the raw source text of a method from its AST node.
+      #
+      # @param node [Ast::Node]
+      # @return [String, nil]
+      def method_source_from_node(node)
+        return node.source if node.source
+
+        return nil unless node.line && node.end_line
+
+        lines = @source_code.lines
+        start_idx = node.line - 1
+        end_idx = node.end_line - 1
+        return nil if start_idx.negative? || end_idx >= lines.length
+
+        lines[start_idx..end_idx].join
+      end
+
+      # Check if a filter string looks like a valid Ruby method name.
+      # Rejects proc/lambda string representations and other non-method filters.
+      #
+      # @param name [String]
+      # @return [Boolean]
+      def valid_method_name?(name)
+        name.match?(/\A[a-z_]\w*[!?=]?\z/i)
+      end
+
+      # Detect columns written by the callback method.
+      #
+      # Scans for self.col= assignments, update_column, update_columns,
+      # write_attribute, and assign_attributes calls, cross-referencing
+      # against the model's known column_names.
+      #
+      # @param method_source [String]
+      # @return [Array<String>]
+      def detect_columns_written(method_source)
+        columns = Set.new
+
+        # Pattern: self.col = value (direct assignment, not ==)
+        method_source.scan(/self\.(\w+)\s*=(?!=)/).flatten.each do |col|
+          columns << col if @column_names.include?(col)
+        end
+
+        # Pattern: update_column(:col, ...) / write_attribute(:col, ...)
+        SINGLE_COLUMN_WRITERS.each do |writer|
+          method_source.scan(/\b#{Regexp.escape(writer)}\s*\(?\s*[:'"](\w+)/).flatten.each do |col|
+            columns << col if @column_names.include?(col)
+          end
+        end
+
+        # Pattern: update_columns(col: ...) / assign_attributes(col: ...)
+        MULTI_COLUMN_WRITERS.each do |writer|
+          method_source.scan(/\b#{Regexp.escape(writer)}\s*\(([^)]+)\)/m).each do |match|
+            match[0].scan(/\b(\w+)\s*:(?!:)/).flatten.each do |col|
+              columns << col if @column_names.include?(col)
+            end
+          end
+        end
+
+        columns.to_a.sort
+      end
+
+      # Detect jobs enqueued by the callback method.
+      #
+      # Matches Job/Worker classes calling async dispatch methods.
+      #
+      # @param method_source [String]
+      # @return [Array<String>]
+      def detect_jobs_enqueued(method_source)
+        async_pattern = ASYNC_METHODS.map { |m| Regexp.escape(m) }.join('|')
+        method_source.scan(/(\w+(?:Job|Worker))\.(?:#{async_pattern})/).flatten.uniq.sort
+      end
+
+      # Detect service objects called by the callback method.
+      #
+      # Matches classes ending in Service followed by a method call.
+      #
+      # @param method_source [String]
+      # @return [Array<String>]
+      def detect_services_called(method_source)
+        method_source.scan(/(\w+Service)(?:\.|::)/).flatten.uniq.sort
+      end
+
+      # Detect mailers triggered by the callback method.
+      #
+      # Matches classes ending in Mailer followed by a method call.
+      #
+      # @param method_source [String]
+      # @return [Array<String>]
+      def detect_mailers_triggered(method_source)
+        method_source.scan(/(\w+Mailer)\./).flatten.uniq.sort
+      end
+
+      # Detect database read operations in the callback method.
+      #
+      # Checks for common ActiveRecord query methods called via dot notation.
+      #
+      # @param method_source [String]
+      # @return [Array<String>]
+      def detect_database_reads(method_source)
+        DB_READ_METHODS.select do |method|
+          method_source.match?(/\.#{Regexp.escape(method)}\b/)
+        end
+      end
+
+      # Extract operations using OperationExtractor from the method's AST node.
+      #
+      # @param method_node [Ast::Node, nil]
+      # @return [Array<Hash>]
+      def extract_operations(method_node)
+        return [] unless method_node
+
+        @operation_extractor.extract(method_node)
+      rescue StandardError
+        []
+      end
+
+      # Return an empty side-effects structure.
+      #
+      # @return [Hash]
+      def empty_side_effects
+        {
+          columns_written: [],
+          jobs_enqueued: [],
+          services_called: [],
+          mailers_triggered: [],
+          database_reads: [],
+          operations: []
+        }
+      end
+    end
+  end
+end

--- a/lib/codebase_index/extractors/configuration_extractor.rb
+++ b/lib/codebase_index/extractors/configuration_extractor.rb
@@ -2,6 +2,7 @@
 
 require_relative 'shared_utility_methods'
 require_relative 'shared_dependency_scanner'
+require_relative 'behavioral_profile'
 
 module CodebaseIndex
   module Extractors
@@ -31,15 +32,23 @@ module CodebaseIndex
                                          .select(&:directory?)
       end
 
-      # Extract all configuration files
+      # Extract all configuration files and the behavioral profile.
       #
       # @return [Array<ExtractedUnit>] List of configuration units
       def extract_all
-        @directories.flat_map do |dir|
+        units = @directories.flat_map do |dir|
           Dir[dir.join('**/*.rb')].filter_map do |file|
             extract_configuration_file(file)
           end
         end
+
+        profile = BehavioralProfile.new.extract
+        units << profile if profile
+
+        units
+      rescue StandardError => e
+        Rails.logger.error("BehavioralProfile integration failed: #{e.message}")
+        units || []
       end
 
       # Extract a single configuration file

--- a/lib/codebase_index/flow_assembler.rb
+++ b/lib/codebase_index/flow_assembler.rb
@@ -136,15 +136,20 @@ module CodebaseIndex
     end
 
     # Prepend before_action callbacks from controller metadata.
+    #
+    # Handles two metadata formats:
+    # - metadata[:callbacks] with :name key (legacy/test format)
+    # - metadata[:filters] with :filter key (ControllerExtractor format)
     def prepend_callbacks(operations, metadata, method_name)
-      callbacks = metadata[:callbacks]
+      callbacks = metadata[:callbacks] || metadata[:filters]
       return unless callbacks.is_a?(Array)
 
       callbacks.each do |cb|
         cb_kind = cb[:kind]&.to_s
         next unless cb_kind == 'before'
 
-        cb_name = cb[:name]
+        # Handle both :name (callbacks format) and :filter (controller filters format)
+        cb_name = cb[:name] || cb[:filter]
         next unless cb_name
 
         # Check if callback applies to this action (via :only/:except)

--- a/lib/codebase_index/flow_precomputer.rb
+++ b/lib/codebase_index/flow_precomputer.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'fileutils'
+require_relative 'flow_assembler'
+
+module CodebaseIndex
+  # Orchestrates pre-computation of request flow maps for all controller actions.
+  #
+  # After the dependency graph is built, FlowPrecomputer iterates controller units,
+  # runs FlowAssembler for each action, and writes flow documents to disk.
+  #
+  # @example
+  #   precomputer = FlowPrecomputer.new(units: all_units, graph: dep_graph, output_dir: out)
+  #   flow_map = precomputer.precompute
+  #   flow_map["OrdersController#create"] #=> "/tmp/codebase_index/flows/OrdersController_create.json"
+  #
+  class FlowPrecomputer
+    # Default maximum recursion depth for flow assembly
+    DEFAULT_MAX_DEPTH = 3
+
+    # @param units [Array<ExtractedUnit>] All extracted units
+    # @param graph [DependencyGraph] The dependency graph
+    # @param output_dir [String] Base output directory
+    # @param max_depth [Integer] Maximum flow assembly depth
+    def initialize(units:, graph:, output_dir:, max_depth: DEFAULT_MAX_DEPTH)
+      @units = units
+      @graph = graph
+      @output_dir = output_dir
+      @max_depth = max_depth
+      @flows_dir = File.join(output_dir, 'flows')
+    end
+
+    # Pre-compute flow documents for all controller actions.
+    #
+    # @return [Hash{String => String}] Map of entry_point to flow file path
+    def precompute
+      FileUtils.mkdir_p(@flows_dir)
+
+      assembler = FlowAssembler.new(graph: @graph, extracted_dir: @output_dir)
+      flow_map = {}
+
+      controller_units.each do |unit|
+        actions = unit.metadata[:actions] || unit.metadata['actions'] || []
+        unit_flow_paths = {}
+
+        actions.each do |action|
+          entry_point = "#{unit.identifier}##{action}"
+          flow_path = assemble_and_write(assembler, entry_point, unit.identifier, action)
+          next unless flow_path
+
+          flow_map[entry_point] = flow_path
+          unit_flow_paths[action] = flow_path
+        end
+
+        unit.metadata[:flow_paths] = unit_flow_paths if unit_flow_paths.any?
+      end
+
+      write_flow_index(flow_map)
+
+      flow_map
+    end
+
+    private
+
+    # Filter units to only controllers.
+    #
+    # @return [Array<ExtractedUnit>]
+    def controller_units
+      @units.select { |u| u.type.to_s == 'controller' }
+    end
+
+    # Assemble a flow for one entry point and write the JSON file.
+    #
+    # @param assembler [FlowAssembler]
+    # @param entry_point [String]
+    # @param controller_id [String]
+    # @param action [String]
+    # @return [String, nil] The written file path, or nil on failure
+    def assemble_and_write(assembler, entry_point, controller_id, action)
+      flow = assembler.assemble(entry_point, max_depth: @max_depth)
+
+      filename = "#{controller_id.gsub('::', '__')}_#{action}.json"
+      flow_path = File.join(@flows_dir, filename)
+
+      File.write(flow_path, JSON.pretty_generate(flow.to_h))
+
+      flow_path
+    rescue StandardError => e
+      Rails.logger.error("[CodebaseIndex] Flow precompute failed for #{entry_point}: #{e.message}")
+      nil
+    end
+
+    # Write the flow index mapping entry points to file paths.
+    #
+    # @param flow_map [Hash{String => String}]
+    def write_flow_index(flow_map)
+      index_path = File.join(@flows_dir, 'flow_index.json')
+      File.write(index_path, JSON.pretty_generate(flow_map))
+    end
+  end
+end

--- a/spec/extractors/behavioral_profile_spec.rb
+++ b/spec/extractors/behavioral_profile_spec.rb
@@ -1,0 +1,438 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'codebase_index/extractors/behavioral_profile'
+
+RSpec.describe CodebaseIndex::Extractors::BehavioralProfile do
+  let(:logger) { double('Logger', error: nil, warn: nil, debug: nil, info: nil) }
+  let(:rails_root) { Pathname.new('/fake/app') }
+  let(:rails_app) { double('RailsApp') }
+  let(:rails_config) { double('RailsConfig') }
+
+  before do
+    stub_const('Rails', double('Rails',
+                               root: rails_root,
+                               logger: logger,
+                               version: '7.1.3',
+                               application: rails_app))
+    allow(rails_app).to receive(:config).and_return(rails_config)
+
+    # Default: nothing is configured
+    allow(rails_config).to receive(:respond_to?).and_return(false)
+    stub_const('RUBY_VERSION', '3.2.2')
+  end
+
+  describe '#extract' do
+    it 'returns an ExtractedUnit' do
+      unit = described_class.new.extract
+      expect(unit).to be_a(CodebaseIndex::ExtractedUnit)
+    end
+
+    it 'sets type to :configuration' do
+      unit = described_class.new.extract
+      expect(unit.type).to eq(:configuration)
+    end
+
+    it 'sets identifier to BehavioralProfile' do
+      unit = described_class.new.extract
+      expect(unit.identifier).to eq('BehavioralProfile')
+    end
+
+    it 'sets file_path to config/application.rb' do
+      unit = described_class.new.extract
+      expect(unit.file_path).to eq('/fake/app/config/application.rb')
+    end
+
+    it 'sets namespace to behavioral_profile' do
+      unit = described_class.new.extract
+      expect(unit.namespace).to eq('behavioral_profile')
+    end
+
+    it 'includes rails_version in metadata' do
+      unit = described_class.new.extract
+      expect(unit.metadata[:rails_version]).to eq('7.1.3')
+    end
+
+    it 'includes ruby_version in metadata' do
+      unit = described_class.new.extract
+      expect(unit.metadata[:ruby_version]).to eq('3.2.2')
+    end
+
+    it 'includes config_type in metadata' do
+      unit = described_class.new.extract
+      expect(unit.metadata[:config_type]).to eq('behavioral_profile')
+    end
+
+    it 'generates a human-readable source_code summary' do
+      unit = described_class.new.extract
+      expect(unit.source_code).to include('Behavioral Profile')
+      expect(unit.source_code).to include('Rails 7.1.3')
+      expect(unit.source_code).to include('Ruby 3.2.2')
+    end
+  end
+
+  # ── Database section ─────────────────────────────────────────────────
+
+  describe 'database extraction' do
+    context 'when ActiveRecord is available with connection_db_config' do
+      let(:db_config) { double('DatabaseConfig', adapter: 'postgresql') }
+      let(:ar_base) { double('ARBase') }
+
+      before do
+        stub_const('ActiveRecord::Base', ar_base)
+        allow(ar_base).to receive(:connection_db_config).and_return(db_config)
+        allow(ar_base).to receive(:respond_to?).with(:connection_db_config).and_return(true)
+        allow(rails_config).to receive(:respond_to?).with(:active_record).and_return(true)
+        ar_config = double('ARConfig')
+        allow(rails_config).to receive(:active_record).and_return(ar_config)
+        allow(ar_config).to receive(:respond_to?).with(:schema_format).and_return(true)
+        allow(ar_config).to receive(:schema_format).and_return(:ruby)
+        allow(ar_config).to receive(:respond_to?).with(:belongs_to_required_by_default).and_return(true)
+        allow(ar_config).to receive(:belongs_to_required_by_default).and_return(true)
+        allow(ar_config).to receive(:respond_to?).with(:has_many_inversing).and_return(true)
+        allow(ar_config).to receive(:has_many_inversing).and_return(true)
+      end
+
+      it 'extracts database adapter' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:database][:adapter]).to eq('postgresql')
+      end
+
+      it 'extracts schema_format' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:database][:schema_format]).to eq(:ruby)
+      end
+
+      it 'extracts belongs_to_required_by_default' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:database][:belongs_to_required_by_default]).to eq(true)
+      end
+
+      it 'extracts has_many_inversing' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:database][:has_many_inversing]).to eq(true)
+      end
+
+      it 'includes adapter in source_code narrative' do
+        unit = described_class.new.extract
+        expect(unit.source_code).to include('postgresql')
+      end
+    end
+
+    context 'when ActiveRecord is not defined' do
+      it 'returns empty database section' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:database]).to eq({})
+      end
+    end
+  end
+
+  # ── Frameworks section ───────────────────────────────────────────────
+
+  describe 'frameworks extraction' do
+    context 'when ActionCable is defined' do
+      before { stub_const('ActionCable', Module.new) }
+
+      it 'detects ActionCable as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:action_cable]).to eq(true)
+      end
+    end
+
+    context 'when ActiveStorage is defined' do
+      before { stub_const('ActiveStorage', Module.new) }
+
+      it 'detects ActiveStorage as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:active_storage]).to eq(true)
+      end
+    end
+
+    context 'when ActionMailbox is defined' do
+      before { stub_const('ActionMailbox', Module.new) }
+
+      it 'detects ActionMailbox as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:action_mailbox]).to eq(true)
+      end
+    end
+
+    context 'when ActionText is defined' do
+      before { stub_const('ActionText', Module.new) }
+
+      it 'detects ActionText as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:action_text]).to eq(true)
+      end
+    end
+
+    context 'when Turbo is defined' do
+      before { stub_const('Turbo', Module.new) }
+
+      it 'detects Turbo as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:turbo]).to eq(true)
+      end
+    end
+
+    context 'when StimulusReflex is defined' do
+      before { stub_const('StimulusReflex', Module.new) }
+
+      it 'detects StimulusReflex as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:stimulus_reflex]).to eq(true)
+      end
+    end
+
+    context 'when SolidQueue is defined' do
+      before { stub_const('SolidQueue', Module.new) }
+
+      it 'detects SolidQueue as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:solid_queue]).to eq(true)
+      end
+    end
+
+    context 'when SolidCache is defined' do
+      before { stub_const('SolidCache', Module.new) }
+
+      it 'detects SolidCache as active' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:frameworks_active][:solid_cache]).to eq(true)
+      end
+    end
+
+    context 'when no optional frameworks are loaded' do
+      it 'marks all frameworks as false' do
+        unit = described_class.new.extract
+        frameworks = unit.metadata[:frameworks_active]
+        expect(frameworks.values).to all(eq(false))
+      end
+    end
+
+    it 'includes detected frameworks in source_code narrative' do
+      stub_const('Turbo', Module.new)
+      stub_const('ActionCable', Module.new)
+
+      unit = described_class.new.extract
+      expect(unit.source_code).to include('Turbo')
+      expect(unit.source_code).to include('ActionCable')
+    end
+  end
+
+  # ── Behavior flags section ──────────────────────────────────────────
+
+  describe 'behavior flags extraction' do
+    context 'when api_only is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:api_only).and_return(true)
+        allow(rails_config).to receive(:api_only).and_return(true)
+      end
+
+      it 'extracts api_only flag' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags][:api_only]).to eq(true)
+      end
+    end
+
+    context 'when eager_load is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:eager_load).and_return(true)
+        allow(rails_config).to receive(:eager_load).and_return(false)
+      end
+
+      it 'extracts eager_load flag' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags][:eager_load]).to eq(false)
+      end
+    end
+
+    context 'when time_zone is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:time_zone).and_return(true)
+        allow(rails_config).to receive(:time_zone).and_return('Eastern Time (US & Canada)')
+      end
+
+      it 'extracts time_zone' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags][:time_zone]).to eq('Eastern Time (US & Canada)')
+      end
+    end
+
+    context 'when session_store is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:session_store).and_return(true)
+        allow(rails_config).to receive(:session_store).and_return(:cookie_store)
+      end
+
+      it 'extracts session_store' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags][:session_store]).to eq(:cookie_store)
+      end
+    end
+
+    context 'when filter_parameters is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:filter_parameters).and_return(true)
+        allow(rails_config).to receive(:filter_parameters).and_return(%i[password token])
+      end
+
+      it 'extracts filter_parameters' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags][:filter_parameters]).to eq(%i[password token])
+      end
+    end
+
+    context 'when action_controller is configured' do
+      before do
+        ac_config = double('ACConfig')
+        allow(rails_config).to receive(:respond_to?).with(:action_controller).and_return(true)
+        allow(rails_config).to receive(:action_controller).and_return(ac_config)
+        allow(ac_config).to receive(:respond_to?).with(:action_on_unpermitted_parameters).and_return(true)
+        allow(ac_config).to receive(:action_on_unpermitted_parameters).and_return(:log)
+      end
+
+      it 'extracts action_on_unpermitted_parameters' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags][:action_on_unpermitted_parameters]).to eq(:log)
+      end
+    end
+
+    context 'when no behavior flags are configured' do
+      it 'returns empty hash for behavior_flags' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:behavior_flags]).to eq({})
+      end
+    end
+  end
+
+  # ── Background processing section ──────────────────────────────────
+
+  describe 'background processing extraction' do
+    context 'when active_job queue_adapter is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:active_job).and_return(true)
+        aj_config = double('AJConfig')
+        allow(rails_config).to receive(:active_job).and_return(aj_config)
+        allow(aj_config).to receive(:respond_to?).with(:queue_adapter).and_return(true)
+        allow(aj_config).to receive(:queue_adapter).and_return(:sidekiq)
+      end
+
+      it 'extracts queue_adapter' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:background_processing][:adapter]).to eq(:sidekiq)
+      end
+    end
+
+    context 'when active_job is not configured' do
+      it 'returns empty hash for background_processing' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:background_processing]).to eq({})
+      end
+    end
+  end
+
+  # ── Caching section ────────────────────────────────────────────────
+
+  describe 'caching extraction' do
+    context 'when cache_store is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:cache_store).and_return(true)
+        allow(rails_config).to receive(:cache_store).and_return(:redis_cache_store)
+      end
+
+      it 'extracts cache_store' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:caching][:store]).to eq(:redis_cache_store)
+      end
+    end
+
+    context 'when cache_store returns an array (store + options)' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:cache_store).and_return(true)
+        allow(rails_config).to receive(:cache_store).and_return([:redis_cache_store, { url: 'redis://localhost' }])
+      end
+
+      it 'extracts the store name from the array' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:caching][:store]).to eq(:redis_cache_store)
+      end
+    end
+
+    context 'when cache_store is not configured' do
+      it 'returns empty hash for caching' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:caching]).to eq({})
+      end
+    end
+  end
+
+  # ── Email section ──────────────────────────────────────────────────
+
+  describe 'email extraction' do
+    context 'when action_mailer is configured' do
+      before do
+        allow(rails_config).to receive(:respond_to?).with(:action_mailer).and_return(true)
+        am_config = double('AMConfig')
+        allow(rails_config).to receive(:action_mailer).and_return(am_config)
+        allow(am_config).to receive(:respond_to?).with(:delivery_method).and_return(true)
+        allow(am_config).to receive(:delivery_method).and_return(:smtp)
+      end
+
+      it 'extracts delivery_method' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:email][:delivery_method]).to eq(:smtp)
+      end
+    end
+
+    context 'when action_mailer is not configured' do
+      it 'returns empty hash for email' do
+        unit = described_class.new.extract
+        expect(unit.metadata[:email]).to eq({})
+      end
+    end
+  end
+
+  # ── Dependencies ───────────────────────────────────────────────────
+
+  describe 'dependencies' do
+    it 'all dependencies have :via key' do
+      stub_const('Turbo', Module.new)
+      stub_const('SolidQueue', Module.new)
+
+      unit = described_class.new.extract
+      unit.dependencies.each do |dep|
+        expect(dep).to have_key(:via), "Dependency #{dep.inspect} missing :via key"
+      end
+    end
+
+    it 'includes detected frameworks as dependencies' do
+      stub_const('Turbo', Module.new)
+      stub_const('ActiveStorage', Module.new)
+
+      unit = described_class.new.extract
+      targets = unit.dependencies.map { |d| d[:target] }
+      expect(targets).to include('Turbo')
+      expect(targets).to include('ActiveStorage')
+    end
+  end
+
+  # ── Graceful failure ───────────────────────────────────────────────
+
+  describe 'graceful failure' do
+    it 'still produces a unit when one section raises' do
+      allow(rails_config).to receive(:respond_to?).with(:cache_store).and_raise(StandardError, 'boom')
+
+      unit = described_class.new.extract
+      expect(unit).to be_a(CodebaseIndex::ExtractedUnit)
+      expect(unit.metadata[:database]).to eq({})
+    end
+
+    it 'returns nil when entire extraction fails' do
+      allow(Rails).to receive(:application).and_raise(StandardError, 'catastrophe')
+
+      unit = described_class.new.extract
+      expect(unit).to be_nil
+    end
+  end
+end

--- a/spec/extractors/callback_analyzer_spec.rb
+++ b/spec/extractors/callback_analyzer_spec.rb
@@ -1,0 +1,352 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'codebase_index/extractors/callback_analyzer'
+
+RSpec.describe CodebaseIndex::Extractors::CallbackAnalyzer do
+  let(:column_names) { %w[email name status role] }
+
+  def build_analyzer(source, columns: column_names)
+    described_class.new(
+      source_code: source,
+      column_names: columns
+    )
+  end
+
+  def make_callback(filter:, type: :before_save, kind: :before, conditions: {})
+    { type: type, filter: filter, kind: kind, conditions: conditions }
+  end
+
+  # ── Column write detection ─────────────────────────────────────
+
+  describe 'column write detection' do
+    it 'detects self.col = assignment' do
+      source = <<~RUBY
+        class User
+          def normalize_email
+            self.email = email.downcase.strip
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'normalize_email'))
+      expect(result[:side_effects][:columns_written]).to include('email')
+    end
+
+    it 'detects update_column calls' do
+      source = <<~RUBY
+        class User
+          def touch_status
+            update_column(:status, 'active')
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'touch_status'))
+      expect(result[:side_effects][:columns_written]).to include('status')
+    end
+
+    it 'detects update_columns calls' do
+      source = <<~RUBY
+        class User
+          def activate
+            update_columns(status: 'active', role: 'member')
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'activate'))
+      expect(result[:side_effects][:columns_written]).to include('status', 'role')
+    end
+
+    it 'detects write_attribute calls' do
+      source = <<~RUBY
+        class User
+          def set_name
+            write_attribute(:name, 'default')
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'set_name'))
+      expect(result[:side_effects][:columns_written]).to include('name')
+    end
+
+    it 'detects assign_attributes calls' do
+      source = <<~RUBY
+        class User
+          def set_defaults
+            assign_attributes(email: 'none@example.com', status: 'pending')
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'set_defaults'))
+      expect(result[:side_effects][:columns_written]).to include('email', 'status')
+    end
+
+    it 'ignores columns not in column_names list' do
+      source = <<~RUBY
+        class User
+          def set_foo
+            self.unknown_column = 'value'
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'set_foo'))
+      expect(result[:side_effects][:columns_written]).to be_empty
+    end
+  end
+
+  # ── Job enqueue detection ──────────────────────────────────────
+
+  describe 'job enqueue detection' do
+    it 'detects perform_later calls' do
+      source = <<~RUBY
+        class User
+          def enqueue_welcome
+            WelcomeJob.perform_later(id)
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'enqueue_welcome'))
+      expect(result[:side_effects][:jobs_enqueued]).to include('WelcomeJob')
+    end
+
+    it 'detects perform_async calls' do
+      source = <<~RUBY
+        class User
+          def sync_data
+            SyncJob.perform_async(id)
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'sync_data'))
+      expect(result[:side_effects][:jobs_enqueued]).to include('SyncJob')
+    end
+  end
+
+  # ── Service call detection ─────────────────────────────────────
+
+  describe 'service call detection' do
+    it 'detects Service.call patterns' do
+      source = <<~RUBY
+        class User
+          def process_signup
+            SignupService.call(user: self)
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'process_signup'))
+      expect(result[:side_effects][:services_called]).to include('SignupService')
+    end
+
+    it 'detects Service.new patterns' do
+      source = <<~RUBY
+        class User
+          def validate_data
+            ValidationService.new(self).run
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'validate_data'))
+      expect(result[:side_effects][:services_called]).to include('ValidationService')
+    end
+  end
+
+  # ── Mailer detection ───────────────────────────────────────────
+
+  describe 'mailer detection' do
+    it 'detects Mailer method calls' do
+      source = <<~RUBY
+        class User
+          def send_welcome
+            UserMailer.welcome(self).deliver_later
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'send_welcome'))
+      expect(result[:side_effects][:mailers_triggered]).to include('UserMailer')
+    end
+  end
+
+  # ── Database read detection ────────────────────────────────────
+
+  describe 'database read detection' do
+    it 'detects find calls' do
+      source = <<~RUBY
+        class User
+          def load_related
+            Post.find(post_id)
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'load_related'))
+      expect(result[:side_effects][:database_reads]).to include('find')
+    end
+
+    it 'detects where calls' do
+      source = <<~RUBY
+        class User
+          def check_siblings
+            User.where(email: email)
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'check_siblings'))
+      expect(result[:side_effects][:database_reads]).to include('where')
+    end
+
+    it 'detects pluck calls' do
+      source = <<~RUBY
+        class User
+          def load_names
+            User.pluck(:name)
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'load_names'))
+      expect(result[:side_effects][:database_reads]).to include('pluck')
+    end
+
+    it 'detects first and last calls' do
+      source = <<~RUBY
+        class User
+          def find_neighbor
+            User.where(status: 'active').first
+            User.where(status: 'active').last
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'find_neighbor'))
+      expect(result[:side_effects][:database_reads]).to include('first', 'last')
+    end
+  end
+
+  # ── Edge cases ─────────────────────────────────────────────────
+
+  describe 'edge cases' do
+    it 'returns empty side_effects for proc/lambda callbacks' do
+      source = <<~RUBY
+        class User
+          before_save -> { self.email = email.downcase }
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: '#<Proc:0x00007f>'))
+      expect(result[:side_effects]).to eq(
+        columns_written: [], jobs_enqueued: [], services_called: [],
+        mailers_triggered: [], database_reads: [], operations: []
+      )
+    end
+
+    it 'returns empty side_effects when method is not found in source' do
+      source = <<~RUBY
+        class User
+          def other_method
+            self.email = 'test'
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'nonexistent_method'))
+      expect(result[:side_effects]).to eq(
+        columns_written: [], jobs_enqueued: [], services_called: [],
+        mailers_triggered: [], database_reads: [], operations: []
+      )
+    end
+
+    it 'preserves the original callback hash fields' do
+      source = <<~RUBY
+        class User
+          def do_stuff
+            self.email = 'test'
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      callback = make_callback(filter: 'do_stuff', type: :before_save, kind: :before, conditions: { if: :active? })
+      result = analyzer.analyze(callback)
+      expect(result[:type]).to eq(:before_save)
+      expect(result[:filter]).to eq('do_stuff')
+      expect(result[:kind]).to eq(:before)
+      expect(result[:conditions]).to eq({ if: :active? })
+      expect(result).to have_key(:side_effects)
+    end
+
+    it 'finds callback methods defined in inlined concern source' do
+      source = <<~RUBY
+        class User < ApplicationRecord
+          def regular_method
+            # nothing
+          end
+
+          # --- inlined from Trackable ---
+          def set_tracking_status
+            self.status = 'tracked'
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'set_tracking_status'))
+      expect(result[:side_effects][:columns_written]).to include('status')
+    end
+  end
+
+  # ── Multiple side effects ──────────────────────────────────────
+
+  describe 'multiple side effects in one callback' do
+    it 'detects all side effect types in a single callback method' do
+      source = <<~RUBY
+        class User
+          def after_create_actions
+            self.status = 'active'
+            WelcomeJob.perform_later(id)
+            AuditService.call(user: self)
+            NotificationMailer.welcome(self).deliver_later
+            Post.where(user_id: id)
+          end
+        end
+      RUBY
+
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'after_create_actions', type: :after_create))
+
+      effects = result[:side_effects]
+      expect(effects[:columns_written]).to include('status')
+      expect(effects[:jobs_enqueued]).to include('WelcomeJob')
+      expect(effects[:services_called]).to include('AuditService')
+      expect(effects[:mailers_triggered]).to include('NotificationMailer')
+      expect(effects[:database_reads]).to include('where')
+    end
+  end
+
+  # ── Operations from OperationExtractor ─────────────────────────
+
+  describe 'operations extraction' do
+    it 'includes operations from OperationExtractor' do
+      source = <<~RUBY
+        class User
+          def process
+            SomeClass.compute
+          end
+        end
+      RUBY
+      analyzer = build_analyzer(source)
+      result = analyzer.analyze(make_callback(filter: 'process'))
+      ops = result[:side_effects][:operations]
+      expect(ops).to be_an(Array)
+      expect(ops).not_to be_empty
+    end
+  end
+end

--- a/spec/flow_precomputer_spec.rb
+++ b/spec/flow_precomputer_spec.rb
@@ -1,0 +1,349 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'json'
+require 'codebase_index/dependency_graph'
+require 'codebase_index/flow_precomputer'
+
+RSpec.describe CodebaseIndex::FlowPrecomputer do
+  let(:output_dir) { Dir.mktmpdir('flow_precomputer_test') }
+  let(:graph) { CodebaseIndex::DependencyGraph.new }
+
+  after { FileUtils.remove_entry(output_dir) }
+
+  # ── Helper ───────────────────────────────────────────────────────────
+
+  def make_unit(type:, identifier:, file_path:, metadata: {}, source_code: '', dependencies: [])
+    unit = CodebaseIndex::ExtractedUnit.new(type: type, identifier: identifier, file_path: file_path)
+    unit.metadata = metadata
+    unit.source_code = source_code
+    unit.dependencies = dependencies
+    unit
+  end
+
+  def write_unit_json(unit)
+    type_dir = File.join(output_dir, "#{unit.type}s")
+    FileUtils.mkdir_p(type_dir)
+    filename = "#{unit.identifier.gsub('::', '__').gsub(/[^a-zA-Z0-9_-]/, '_')}.json"
+    File.write(File.join(type_dir, filename), JSON.generate(unit.to_h))
+  end
+
+  # ── Basic behavior ──────────────────────────────────────────────────
+
+  describe '#precompute' do
+    it 'returns a hash mapping entry points to flow file paths' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'PostsController',
+        file_path: 'app/controllers/posts_controller.rb',
+        metadata: {
+          actions: %w[index create],
+          filters: [
+            { kind: :before, filter: :authenticate_user! }
+          ]
+        },
+        source_code: <<~RUBY
+          class PostsController < ApplicationController
+            def index
+              @posts = Post.all
+            end
+
+            def create
+              Post.create!(params)
+            end
+          end
+        RUBY
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      result = precomputer.precompute
+
+      expect(result).to be_a(Hash)
+      expect(result.keys).to contain_exactly('PostsController#index', 'PostsController#create')
+      result.each_value do |path|
+        expect(File.exist?(path)).to eq(true)
+      end
+    end
+
+    it 'writes flow documents as JSON files' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'OrdersController',
+        file_path: 'app/controllers/orders_controller.rb',
+        metadata: { actions: %w[create] },
+        source_code: <<~RUBY
+          class OrdersController < ApplicationController
+            def create
+              Order.create!(params)
+            end
+          end
+        RUBY
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      precomputer.precompute
+
+      flow_path = File.join(output_dir, 'flows', 'OrdersController_create.json')
+      expect(File.exist?(flow_path)).to eq(true)
+
+      flow_data = JSON.parse(File.read(flow_path), symbolize_names: true)
+      expect(flow_data[:entry_point]).to eq('OrdersController#create')
+      expect(flow_data[:steps]).to be_an(Array)
+    end
+
+    it 'writes flow_index.json' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'UsersController',
+        file_path: 'app/controllers/users_controller.rb',
+        metadata: { actions: %w[show] },
+        source_code: <<~RUBY
+          class UsersController < ApplicationController
+            def show
+              @user = User.find(params[:id])
+            end
+          end
+        RUBY
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      precomputer.precompute
+
+      index_path = File.join(output_dir, 'flows', 'flow_index.json')
+      expect(File.exist?(index_path)).to eq(true)
+
+      index = JSON.parse(File.read(index_path))
+      expect(index).to have_key('UsersController#show')
+    end
+
+    it 'adds flow references to controller unit metadata' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'ItemsController',
+        file_path: 'app/controllers/items_controller.rb',
+        metadata: { actions: %w[index] },
+        source_code: <<~RUBY
+          class ItemsController < ApplicationController
+            def index
+              @items = Item.all
+            end
+          end
+        RUBY
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      precomputer.precompute
+
+      expect(controller.metadata[:flow_paths]).to be_a(Hash)
+      expect(controller.metadata[:flow_paths]).to have_key('index')
+    end
+  end
+
+  # ── Controller with filters ────────────────────────────────────────
+
+  describe 'controller with filters' do
+    it 'includes before_action filters in flow steps' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'AdminController',
+        file_path: 'app/controllers/admin_controller.rb',
+        metadata: {
+          actions: %w[dashboard],
+          filters: [
+            { kind: :before, filter: :require_admin }
+          ]
+        },
+        source_code: <<~RUBY
+          class AdminController < ApplicationController
+            def dashboard
+              @stats = Stats.compute
+            end
+          end
+        RUBY
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      precomputer.precompute
+
+      flow_path = File.join(output_dir, 'flows', 'AdminController_dashboard.json')
+      flow_data = JSON.parse(File.read(flow_path), symbolize_names: true)
+
+      ops = flow_data[:steps].first[:operations]
+      callback_op = ops.find { |o| o[:method] == 'require_admin' }
+      expect(callback_op).not_to be_nil
+    end
+  end
+
+  # ── Multiple controllers ────────────────────────────────────────────
+
+  describe 'multiple controllers' do
+    it 'processes all controller units' do
+      ctrl_a = make_unit(
+        type: :controller,
+        identifier: 'AController',
+        file_path: 'app/controllers/a_controller.rb',
+        metadata: { actions: %w[index] },
+        source_code: "class AController < ApplicationController\n  def index; end\nend"
+      )
+      ctrl_b = make_unit(
+        type: :controller,
+        identifier: 'BController',
+        file_path: 'app/controllers/b_controller.rb',
+        metadata: { actions: %w[show] },
+        source_code: "class BController < ApplicationController\n  def show; end\nend"
+      )
+      [ctrl_a, ctrl_b].each do |u|
+        write_unit_json(u)
+        graph.register(u)
+      end
+
+      precomputer = described_class.new(units: [ctrl_a, ctrl_b], graph: graph, output_dir: output_dir)
+      result = precomputer.precompute
+
+      expect(result.keys).to contain_exactly('AController#index', 'BController#show')
+    end
+  end
+
+  # ── Edge cases ─────────────────────────────────────────────────────
+
+  describe 'edge cases' do
+    it 'handles controller with no actions gracefully' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'EmptyController',
+        file_path: 'app/controllers/empty_controller.rb',
+        metadata: { actions: [] },
+        source_code: "class EmptyController < ApplicationController\nend"
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      result = precomputer.precompute
+
+      expect(result).to eq({})
+    end
+
+    it 'handles controller with nil actions gracefully' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'NoActionsController',
+        file_path: 'app/controllers/no_actions_controller.rb',
+        metadata: {},
+        source_code: "class NoActionsController < ApplicationController\nend"
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      result = precomputer.precompute
+
+      expect(result).to eq({})
+    end
+
+    it 'skips non-controller units' do
+      service = make_unit(
+        type: :service,
+        identifier: 'PostService',
+        file_path: 'app/services/post_service.rb',
+        metadata: {},
+        source_code: "class PostService\n  def call; end\nend"
+      )
+      write_unit_json(service)
+      graph.register(service)
+
+      precomputer = described_class.new(units: [service], graph: graph, output_dir: output_dir)
+      result = precomputer.precompute
+
+      expect(result).to eq({})
+    end
+
+    it 'handles FlowAssembler errors gracefully per action' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'BadController',
+        file_path: 'app/controllers/bad_controller.rb',
+        metadata: { actions: %w[ok broken] },
+        source_code: <<~RUBY
+          class BadController < ApplicationController
+            def ok
+              render plain: 'ok'
+            end
+
+            def broken
+              do_something
+            end
+          end
+        RUBY
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      # Stub FlowAssembler to raise only for the broken action
+      assembler_double = instance_double(CodebaseIndex::FlowAssembler)
+      allow(CodebaseIndex::FlowAssembler).to receive(:new).and_return(assembler_double)
+
+      ok_flow = CodebaseIndex::FlowDocument.new(
+        entry_point: 'BadController#ok',
+        steps: [{ unit: 'BadController#ok', type: 'controller', operations: [] }]
+      )
+      allow(assembler_double).to receive(:assemble)
+        .with('BadController#ok', max_depth: 3)
+        .and_return(ok_flow)
+      allow(assembler_double).to receive(:assemble)
+        .with('BadController#broken', max_depth: 3)
+        .and_raise(StandardError, 'parse error')
+
+      logger = double('Logger', error: nil, warn: nil, info: nil, debug: nil)
+      stub_const('Rails', double('Rails', logger: logger))
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      result = precomputer.precompute
+
+      # Should still have the ok action
+      expect(result).to have_key('BadController#ok')
+      expect(result).not_to have_key('BadController#broken')
+    end
+  end
+
+  # ── Depth limiting ─────────────────────────────────────────────────
+
+  describe 'depth limiting' do
+    it 'passes max_depth to FlowAssembler' do
+      controller = make_unit(
+        type: :controller,
+        identifier: 'DeepController',
+        file_path: 'app/controllers/deep_controller.rb',
+        metadata: { actions: %w[go] },
+        source_code: "class DeepController < ApplicationController\n  def go; end\nend"
+      )
+      write_unit_json(controller)
+      graph.register(controller)
+
+      assembler_double = instance_double(CodebaseIndex::FlowAssembler)
+      allow(CodebaseIndex::FlowAssembler).to receive(:new).and_return(assembler_double)
+
+      flow = CodebaseIndex::FlowDocument.new(
+        entry_point: 'DeepController#go',
+        steps: []
+      )
+      expect(assembler_double).to receive(:assemble)
+        .with('DeepController#go', max_depth: 3)
+        .and_return(flow)
+
+      precomputer = described_class.new(units: [controller], graph: graph, output_dir: output_dir)
+      precomputer.precompute
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Enriches extraction output with behavioral information that answers "what happens when X runs?" — not just "what exists." Motivated by real-world testing on a large Rails app where the structural index couldn't help agents during a Rails 7.0→7.1 upgrade.

- **Callback side-effect enrichment** — `CallbackAnalyzer` detects columns written, jobs enqueued, services/mailers called, and DB reads in callback method bodies. ModelExtractor enriches each callback with `:side_effects` metadata. New `:callback_effects` chunk type provides lifecycle-grouped narrative summaries.
- **Behavioral profile** — `BehavioralProfile` introspects resolved `Rails.application.config` values (DB adapter, active frameworks, behavior flags, job adapter, cache store, email config) into a single `ExtractedUnit`. Integrated into `ConfigurationExtractor` output.
- **Pre-computed request flow maps** — `FlowPrecomputer` generates per-action flow documents from controller units using existing `FlowAssembler`. Fixes `FlowAssembler` bug where `prepend_callbacks` expected `:callbacks` key but controller metadata uses `:filters`. New `precompute_flows` config flag (opt-in, default false).

## Test plan
- [x] 87 new specs across 6 files (callback_analyzer, behavioral_profile, flow_precomputer + modified model_extractor, config_extractor, flow_assembler)
- [x] Full suite: 2270 examples, 0 failures, 2 pending (pre-existing)
- [x] Rubocop: 267 files, 0 offenses
- [ ] Integration validation in compose-dev/admin (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)