### PR TITLE
Add CODEOWNERS, issue routing, and improved PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default: require review from maintainer on all PRs
+* @LeahArmstrong

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/LeahArmstrong/codebase_index/discussions/categories/q-a
+    about: Ask the community for help — please don't open issues for questions.
+  - name: Ideas & Feature Discussion
+    url: https://github.com/LeahArmstrong/codebase_index/discussions/categories/ideas
+    about: Discuss feature ideas before opening a formal request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,15 @@ Brief description of the changes.
 
 ## Motivation
 
-Why is this change needed?
+Why is this change needed? Link any related issues (e.g., `Fixes #123`).
+
+## Changes
+
+- ...
 
 ## Testing
 
-How was this tested?
+How was this tested? Include relevant specs or manual verification steps.
 
 ## Checklist
 
@@ -16,3 +20,4 @@ How was this tested?
 - [ ] `bundle exec rake spec` passes
 - [ ] `bundle exec rubocop` passes
 - [ ] CHANGELOG.md updated (if user-facing change)
+- [ ] Documentation updated (if applicable)


### PR DESCRIPTION
## Summary

- **CODEOWNERS** — auto-requests @LeahArmstrong review on all PRs
- **Issue template config** — routes questions/ideas to Discussions, disables blank issues
- **PR template** — adds Changes section, issue linking prompt, and docs checklist item

## Testing

Configuration-only changes. Verified files render correctly locally.