### PR TITLE
Fix duplicate URI warning in gemspec

### DIFF
--- a/codebase_index.gemspec
+++ b/codebase_index.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = "#{spec.homepage}/tree/main"
   spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata['bug_tracker_uri'] = "#{spec.homepage}/issues"
   spec.metadata['documentation_uri'] = "#{spec.homepage}/tree/main/docs"


### PR DESCRIPTION
## Summary

- Differentiates `source_code_uri` from `homepage_uri` by pointing to `/tree/main`
- Eliminates the `gem build` warning: "You have specified the uri for all of the following keys: homepage_uri, source_code_uri"

## Testing

`gem build codebase_index.gemspec` produces zero warnings.