### PR TITLE
Fix Prism cross-version compat and spec portability

### DIFF
--- a/spec/extractors/view_template_extractor_spec.rb
+++ b/spec/extractors/view_template_extractor_spec.rb
@@ -178,11 +178,15 @@ RSpec.describe CodebaseIndex::Extractors::ViewTemplateExtractor do
 
     context 'when file read fails' do
       before do
-        path = create_file('app/views/broken/index.html.erb', 'content')
-        File.chmod(0o000, path)
+        create_file('app/views/broken/index.html.erb', 'content')
       end
 
       it 'skips the file and returns empty array' do
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(
+          a_string_matching(%r{app/views/broken/index\.html\.erb})
+        ).and_raise(Errno::EACCES)
+
         units = described_class.new.extract_all
         expect(units).to eq([])
       end

--- a/spec/support/shared_extractor_context.rb
+++ b/spec/support/shared_extractor_context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 RSpec.shared_context 'extractor setup' do
   let(:tmp_dir) { Dir.mktmpdir }
   let(:rails_root) { Pathname.new(tmp_dir) }


### PR DESCRIPTION
## Summary
- Add `prism_else_clause()` helper with `respond_to?` guards for Prism <1.0 / >=1.0 API differences (consequent vs else_clause vs subsequent)
- Fix `ConstantPathNode` name access for Prism versions where `.name` was renamed to `.child.name`
- Replace `File.chmod(0o000)` with `File.read` stub in view template spec (chmod has no effect under root/CI)
- Add missing `require 'pathname'` in shared extractor context

Extracted from PRs #18 and #19 which both carried identical copies of these fixes. Merging this first eliminates the conflict.

## Test plan
- [x] Full suite: 3151 examples, 0 failures
- [x] Rubocop: 0 offenses