### PR TITLE
Fix vendor path leak in source file resolution

### DIFF
--- a/lib/codebase_index/extractors/graphql_extractor.rb
+++ b/lib/codebase_index/extractors/graphql_extractor.rb
@@ -202,39 +202,16 @@ module CodebaseIndex
       # Determine the source file for a runtime-loaded class, validating that
       # paths are within Rails.root to avoid returning graphql gem internals.
       #
-      # Uses a multi-tier strategy matching the model extractor's pattern.
+      # Convention path first, then introspection via {#resolve_source_location}
+      # which filters out vendor/node_modules paths.
       #
       # @param klass [Class]
       # @return [String] Absolute path to the source file
       def source_file_for_class(klass)
-        app_root = Rails.root.to_s
         convention_path = Rails.root.join("#{GRAPHQL_DIRECTORY}/#{klass.name.underscore}.rb").to_s
-
-        # Tier 1: Instance methods defined directly on this class
-        klass.instance_methods(false).each do |method_name|
-          loc = klass.instance_method(method_name).source_location&.first
-          return loc if loc&.start_with?(app_root)
-        end
-
-        # Tier 2: Singleton methods defined on this class
-        klass.singleton_methods(false).each do |method_name|
-          loc = klass.method(method_name).source_location&.first
-          return loc if loc&.start_with?(app_root)
-        end
-
-        # Tier 3: Convention path if file exists
         return convention_path if File.exist?(convention_path)
 
-        # Tier 4: const_source_location (Ruby 3.0+)
-        if Object.respond_to?(:const_source_location)
-          loc = Object.const_source_location(klass.name)&.first
-          return loc if loc&.start_with?(app_root)
-        end
-
-        # Tier 5: Always return convention path — never a gem path
-        convention_path
-      rescue StandardError
-        Rails.root.join("#{GRAPHQL_DIRECTORY}/#{klass.name.underscore}.rb").to_s
+        resolve_source_location(klass, app_root: Rails.root.to_s, fallback: convention_path)
       end
 
       # ──────────────────────────────────────────────────────────────────────

--- a/lib/codebase_index/extractors/mailer_extractor.rb
+++ b/lib/codebase_index/extractors/mailer_extractor.rb
@@ -71,13 +71,18 @@ module CodebaseIndex
 
       private
 
+      # Locate the source file for a mailer class.
+      #
+      # Convention path first, then introspection via {#resolve_source_location}
+      # which filters out vendor/node_modules paths.
+      #
+      # @param mailer [Class]
+      # @return [String]
       def source_file_for(mailer)
-        if mailer.instance_methods(false).any?
-          method = mailer.instance_methods(false).first
-          mailer.instance_method(method).source_location&.first
-        end || Rails.root.join("app/mailers/#{mailer.name.underscore}.rb").to_s
-      rescue StandardError
-        Rails.root.join("app/mailers/#{mailer.name.underscore}.rb").to_s
+        convention_path = Rails.root.join("app/mailers/#{mailer.name.underscore}.rb").to_s
+        return convention_path if File.exist?(convention_path)
+
+        resolve_source_location(mailer, app_root: Rails.root.to_s, fallback: convention_path)
       end
 
       # ──────────────────────────────────────────────────────────────────────

--- a/lib/codebase_index/extractors/view_component_extractor.rb
+++ b/lib/codebase_index/extractors/view_component_extractor.rb
@@ -86,7 +86,10 @@ module CodebaseIndex
         defined?(ViewComponent::Preview) && klass < ViewComponent::Preview
       end
 
-      # Locate the source file for a component class
+      # Locate the source file for a component class.
+      #
+      # Convention paths first, then introspection via {#resolve_source_location}
+      # which filters out vendor/node_modules paths.
       #
       # @param component [Class]
       # @return [String, nil]
@@ -99,13 +102,7 @@ module CodebaseIndex
         found = possible_paths.find { |p| File.exist?(p) }
         return found.to_s if found
 
-        # Fall back to method source location
-        if component.instance_methods(false).any?
-          method = component.instance_methods(false).first
-          component.instance_method(method).source_location&.first
-        end
-      rescue StandardError
-        nil
+        resolve_source_location(component, app_root: Rails.root.to_s, fallback: nil)
       end
 
       # @param file_path [String, nil]

--- a/spec/extractors/action_cable_extractor_spec.rb
+++ b/spec/extractors/action_cable_extractor_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CodebaseIndex::Extractors::ActionCableExtractor do
   before do
     stub_const('CodebaseIndex::ModelNameCache',
                double('ModelNameCache', model_names_regex: /\b(?:User|Post|Room)\b/))
+    stub_rails_root('/rails')
   end
 
   describe '#extract_all' do
@@ -573,6 +574,7 @@ RSpec.describe CodebaseIndex::Extractors::ActionCableExtractor do
     channel = double(name || 'anonymous')
     allow(channel).to receive(:name).and_return(name)
     allow(channel).to receive(:instance_methods).with(false).and_return(public_methods)
+    allow(channel).to receive(:methods).with(false).and_return([])
     stub_channel_source_location(channel, source_location)
     stub_channel_file_reading(source_location, source)
     channel

--- a/spec/extractors/graphql_extractor_spec.rb
+++ b/spec/extractors/graphql_extractor_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CodebaseIndex::Extractors::GraphQLExtractor do
       allow(klass).to receive(:instance_method).with(:resolve).and_return(
         double('UnboundMethod', source_location: [gem_path, 1])
       )
-      allow(klass).to receive(:singleton_methods).with(false).and_return([])
+      allow(klass).to receive(:methods).with(false).and_return([])
 
       result = extractor.send(:source_file_for_class, klass)
 
@@ -84,6 +84,7 @@ RSpec.describe CodebaseIndex::Extractors::GraphQLExtractor do
       allow(klass).to receive(:instance_method).with(:resolve).and_return(
         double('UnboundMethod', source_location: [app_path, 5])
       )
+      allow(klass).to receive(:methods).with(false).and_return([])
 
       result = extractor.send(:source_file_for_class, klass)
 
@@ -100,7 +101,7 @@ RSpec.describe CodebaseIndex::Extractors::GraphQLExtractor do
       allow(klass).to receive(:instance_method).with(:resolve).and_return(
         double('UnboundMethod', source_location: [gem_path, 1])
       )
-      allow(klass).to receive(:singleton_methods).with(false).and_return([:authorized?])
+      allow(klass).to receive(:methods).with(false).and_return([:authorized?])
       allow(klass).to receive(:method).with(:authorized?).and_return(
         double('Method', source_location: [app_path, 3])
       )
@@ -114,7 +115,7 @@ RSpec.describe CodebaseIndex::Extractors::GraphQLExtractor do
       klass = double('TypeClass')
       allow(klass).to receive(:name).and_return('Types::PostType')
       allow(klass).to receive(:instance_methods).with(false).and_return([])
-      allow(klass).to receive(:singleton_methods).with(false).and_return([])
+      allow(klass).to receive(:methods).with(false).and_return([])
 
       result = extractor.send(:source_file_for_class, klass)
 


### PR DESCRIPTION
## Summary

- Add `app_source?` and `resolve_source_location` shared helpers to `SharedUtilityMethods` that filter out vendor bundle and node_modules paths
- Standardize all 9 extractors (model, controller, graphql, view_component, phlex, serializer, mailer, job, action_cable) to use convention-path-first resolution with vendor filtering
- Remove duplicate `condition_label` from ModelExtractor (identical to SharedUtilityMethods version)

## Problem

In Docker environments where `Rails.root = /app`, the `start_with?(app_root)` check incorrectly accepted vendor bundle paths like `/app/vendor/bundle/ruby/3.x/gems/activerecord-7.0.8.7/lib/active_record/base.rb` because they start with `/app`. This caused ~50% of models, ~27% of controllers, and ~40% of GraphQL types to get wrong `file_path` and `source_code`.

## Test plan

- [x] Full gem test suite passes (3243 examples, 0 failures)
- [x] Verified in host app extraction: 0 wrong across all application categories
- [ ] Review `app_source?` filtering covers expected exclusion patterns
- [ ] Review `resolve_source_location` tier ordering (const_source_location > instance methods > class methods)