### PR TITLE
Fix Notion sync returning 0 columns

### DIFF
--- a/lib/codebase_index/extractors/model_extractor.rb
+++ b/lib/codebase_index/extractors/model_extractor.rb
@@ -348,9 +348,13 @@ module CodebaseIndex
           table_exists: model.table_exists?,
           column_count: model.table_exists? ? model.columns.size : 0,
           column_names: model.table_exists? ? model.column_names : [],
-          columns: model.table_exists? ? model.columns.map { |col|
-            { 'name' => col.name, 'type' => col.sql_type, 'null' => col.null, 'default' => col.default }
-          } : [],
+          columns: if model.table_exists?
+                     model.columns.map do |col|
+                       { 'name' => col.name, 'type' => col.sql_type, 'null' => col.null, 'default' => col.default }
+                     end
+                   else
+                     []
+                   end,
 
           # ActiveStorage / ActionText
           active_storage_attachments: extract_active_storage_attachments(source),

--- a/lib/codebase_index/extractors/model_extractor.rb
+++ b/lib/codebase_index/extractors/model_extractor.rb
@@ -348,6 +348,9 @@ module CodebaseIndex
           table_exists: model.table_exists?,
           column_count: model.table_exists? ? model.columns.size : 0,
           column_names: model.table_exists? ? model.column_names : [],
+          columns: model.table_exists? ? model.columns.map { |col|
+            { 'name' => col.name, 'type' => col.sql_type, 'null' => col.null, 'default' => col.default }
+          } : [],
 
           # ActiveStorage / ActionText
           active_storage_attachments: extract_active_storage_attachments(source),


### PR DESCRIPTION
## Summary
- **Bug:** `Notion::Exporter#sync_model_columns` reads `metadata['columns']` expecting objects with `name`/`type`/`null`/`default`, but `ModelExtractor` only wrote `column_names` (flat strings) and `column_count` (integer)
- **Effect:** Key mismatch → `|| []` fallback → zero iterations → 0 columns synced, no errors
- **Fix:** Add `columns` key to `extract_metadata` with the rich column objects the exporter expects

## Test plan
- [ ] Re-run `codebase_index:extract` in host Rails app to regenerate JSON
- [ ] Verify JSON output contains `metadata.columns` array with `name`/`type`/`null`/`default` per column
- [ ] Run `codebase_index:notion_sync` and confirm columns sync to Notion
- [ ] Verify existing consumers of `column_names`/`column_count` still work (keys preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)