### PR TITLE
Add Ruby API guide and response examples for Context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,6 +1,9 @@
 {
+  "$schema": "https://context7.com/schema/v1.json",
   "url": "https://context7.com/leaharmstrong/codebase_index",
   "public_key": "pk_lHvYkoK2DwC8Cbj0p10kg",
+  "projectTitle": "CodebaseIndex",
+  "description": "Ruby gem that extracts structured data from Rails applications for AI-assisted development. Uses runtime introspection to produce version-accurate representations with inlined concerns, resolved callback chains, schema-aware associations, and dependency graphs.",
   "folders": ["docs"],
   "excludeFolders": [
     "docs/design",
@@ -15,5 +18,11 @@
     "docs/TOKEN_BENCHMARK.md",
     "docs/COVERAGE_GAP_ANALYSIS.md",
     "docs/USE_CASES_AND_FEATURE_GAPS.md"
+  ],
+  "rules": [
+    "CodebaseIndex requires a booted Rails environment for extraction. The MCP Index Server reads pre-extracted JSON and does NOT require Rails.",
+    "Primary interfaces: two MCP servers (Index Server for structural queries, Console Server for live data), rake tasks for extraction, and a Ruby API (IndexReader, DependencyGraph, Retriever) for scripting.",
+    "ExtractedUnit is the universal data structure — type, identifier, file_path, source_code, metadata, dependencies, dependents, chunks.",
+    "The dependency graph is bidirectional with PageRank scoring. GraphAnalyzer detects orphans, hubs, cycles, bridges."
   ]
 }

--- a/docs/EXTRACTOR_REFERENCE.md
+++ b/docs/EXTRACTOR_REFERENCE.md
@@ -558,6 +558,23 @@ Every extractor returns `Array<ExtractedUnit>`. An `ExtractedUnit` is a self-con
 - Additional gems can be indexed via `config.add_gem "devise", paths: [...]`
 - This is what makes framework-specific queries accurate: "what options does `has_many` support?" returns the actual source for the installed Rails version
 
+**Example output (abbreviated):**
+
+```json
+{
+  "type": "rails_source",
+  "identifier": "ActiveRecord::Associations::ClassMethods",
+  "file_path": "/path/to/gems/activerecord-7.2.0/lib/active_record/associations.rb",
+  "source_code": "module ActiveRecord\n  module Associations\n    module ClassMethods\n      def has_many(name, scope = nil, **options, &extension)\n        ...\n      end\n      ...\n    end\n  end\nend",
+  "metadata": {
+    "gem": "activerecord",
+    "version": "7.2.0",
+    "priority": "high"
+  },
+  "dependencies": []
+}
+```
+
 ---
 
 ## How Do I Enable or Disable Extractors?
@@ -633,6 +650,31 @@ If the host app is a git repo, the following are added to `metadata[:git]` after
 | `contributors` | Top 5 contributors by commit count: `[{ name:, commits: }]` |
 | `recent_commits` | Last 5 commits: `[{ sha:, message:, date:, author: }]` |
 | `change_frequency` | `:new`, `:hot`, `:active`, `:stable`, or `:dormant` |
+
+**Full git enrichment JSON example:**
+
+```json
+{
+  "git": {
+    "last_modified": "2025-02-15T10:22:00Z",
+    "last_author": "Alice",
+    "commit_count": 47,
+    "change_frequency": "hot",
+    "contributors": [
+      { "name": "Alice", "commits": 22 },
+      { "name": "Bob", "commits": 15 },
+      { "name": "Carol", "commits": 10 }
+    ],
+    "recent_commits": [
+      { "sha": "abc1234", "message": "Add status validation to Order", "date": "2025-02-15", "author": "Alice" },
+      { "sha": "def5678", "message": "Fix total calculation edge case", "date": "2025-02-10", "author": "Bob" },
+      { "sha": "ghi9012", "message": "Refactor callbacks for clarity", "date": "2025-02-05", "author": "Alice" },
+      { "sha": "jkl3456", "message": "Add line item discount support", "date": "2025-01-28", "author": "Carol" },
+      { "sha": "mno7890", "message": "Initial order model setup", "date": "2025-01-15", "author": "Alice" }
+    ]
+  }
+}
+```
 
 ### Full Example JSON
 

--- a/docs/MCP_TOOL_COOKBOOK.md
+++ b/docs/MCP_TOOL_COOKBOOK.md
@@ -16,9 +16,30 @@ Scenario-based examples showing which tool to use, what parameters to pass, and 
 }
 ```
 
-Returns the manifest (unit counts by type, git SHA, extraction timestamp) plus the full `SUMMARY.md` overview. Use `detail: "summary"` for just the counts.
+**Example response:**
 
-**What you'll get:** Total units broken down by type (models, controllers, services, jobs, etc.), the git commit the extraction reflects, and when it ran.
+```json
+{
+  "manifest": {
+    "extracted_at": "2025-03-01T14:30:00Z",
+    "git_sha": "abc1234",
+    "unit_counts": {
+      "model": 42,
+      "controller": 18,
+      "service": 25,
+      "job": 12,
+      "mailer": 5,
+      "route": 87,
+      "concern": 15,
+      "view_template": 60
+    },
+    "total_units": 310
+  },
+  "summary": "# Codebase Summary\n\n42 models, 18 controllers, 25 services, 12 jobs..."
+}
+```
+
+Use `detail: "summary"` for just the counts without the full summary text.
 
 ---
 
@@ -33,7 +54,42 @@ Returns the manifest (unit counts by type, git SHA, extraction timestamp) plus t
 }
 ```
 
-**What you'll get:** Full annotated source with inlined concerns, schema comments, associations, callbacks, and validations — everything needed to understand the model without opening the file.
+**Example response:**
+
+```json
+{
+  "identifier": "User",
+  "type": "model",
+  "file_path": "app/models/user.rb",
+  "source_code": "# == Schema Information\n# id :bigint not null, pk\n# email :string not null\n# name :string\n# created_at :datetime\n#\nclass User < ApplicationRecord\n  has_many :orders\n  has_many :comments\n  validates :email, presence: true, uniqueness: true\n  ...\nend\n\n# --- Concern: Searchable ---\nmodule Searchable\n  ...\nend",
+  "metadata": {
+    "associations": [
+      { "type": "has_many", "name": "orders", "model": "Order" },
+      { "type": "has_many", "name": "comments", "model": "Comment" }
+    ],
+    "validations": [
+      { "attribute": "email", "kind": "presence" },
+      { "attribute": "email", "kind": "uniqueness" }
+    ],
+    "callbacks": [],
+    "inlined_concerns": ["Searchable"],
+    "git": {
+      "last_modified": "2025-02-15T10:22:00Z",
+      "last_author": "Alice",
+      "commit_count": 23,
+      "change_frequency": "active"
+    }
+  },
+  "dependencies": [
+    { "type": "model", "target": "Order", "via": "has_many" },
+    { "type": "model", "target": "Comment", "via": "has_many" }
+  ],
+  "dependents": [
+    { "type": "controller", "identifier": "UsersController" },
+    { "type": "service", "identifier": "AuthenticationService" }
+  ]
+}
+```
 
 To focus on just associations and callbacks without the full source:
 
@@ -58,7 +114,22 @@ To focus on just associations and callbacks without the full source:
 }
 ```
 
-**What you'll get:** A BFS tree of everything that references `User` — controllers, services, jobs, mailers — up to 2 hops out. Set `depth: 1` for direct dependents only.
+**Example response:**
+
+```json
+{
+  "root": "User",
+  "found": true,
+  "nodes": {
+    "User": { "type": "model", "depth": 0, "deps": ["UsersController", "AuthenticationService", "OrdersController"] },
+    "UsersController": { "type": "controller", "depth": 1, "deps": ["AdminDashboardController"] },
+    "AuthenticationService": { "type": "service", "depth": 1, "deps": ["SessionsController"] },
+    "OrdersController": { "type": "controller", "depth": 1, "deps": [] }
+  }
+}
+```
+
+Set `depth: 1` for direct dependents only.
 
 To find only which jobs depend on `User`:
 
@@ -301,7 +372,26 @@ Start with performance metrics from the Console Server, then trace the code path
 }
 ```
 
-**What you'll get:** Relevant Rails source units matching the keyword — the actual implementation from the installed gem. Useful for understanding framework behavior without leaving your AI tool.
+**Example response:**
+
+```json
+[
+  {
+    "identifier": "ActiveRecord::Associations::ClassMethods",
+    "type": "rails_source",
+    "file_path": "/path/to/gems/activerecord-7.2.0/lib/active_record/associations.rb",
+    "metadata": { "gem": "activerecord", "version": "7.2.0" }
+  },
+  {
+    "identifier": "ActiveRecord::Associations::Builder::HasMany",
+    "type": "rails_source",
+    "file_path": "/path/to/gems/activerecord-7.2.0/lib/active_record/associations/builder/has_many.rb",
+    "metadata": { "gem": "activerecord", "version": "7.2.0" }
+  }
+]
+```
+
+Useful for understanding framework behavior without leaving your AI tool — returns the actual implementation from the installed gem.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ What's next: see [COVERAGE_GAP_ANALYSIS.md](COVERAGE_GAP_ANALYSIS.md) for remain
 | [WHY_CODEBASE_INDEX.md](WHY_CODEBASE_INDEX.md) | What CodebaseIndex is, why it exists, before/after examples |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Pipeline stages, ExtractedUnit, dependency graph, retrieval, storage backends, MCP servers |
 | [EXTRACTOR_REFERENCE.md](EXTRACTOR_REFERENCE.md) | Per-extractor documentation — what each of the 34 extractors captures, edge cases, example output |
+| [RUBY_API_GUIDE.md](RUBY_API_GUIDE.md) | Programmatic Ruby API — IndexReader, DependencyGraph, Retriever, with executable examples |
 | [MCP_TOOL_COOKBOOK.md](MCP_TOOL_COOKBOOK.md) | Scenario-based MCP tool examples — question → tool → parameters → expected output |
 
 ## Reference

--- a/docs/RUBY_API_GUIDE.md
+++ b/docs/RUBY_API_GUIDE.md
@@ -1,0 +1,483 @@
+# Ruby API Guide
+
+CodebaseIndex provides a Ruby API for programmatic access to extraction output. Use it when you need to script queries, build custom tooling, or integrate codebase data into your own workflows.
+
+**When to use what:**
+
+| Interface | Best for |
+|-----------|----------|
+| MCP servers | AI tools (Claude Code, Cursor, Windsurf) — no Ruby needed |
+| Rake tasks | CLI extraction and validation |
+| Ruby API | Custom scripts, CI pipelines, programmatic queries |
+
+---
+
+## Programmatic Extraction
+
+Extraction requires a booted Rails environment. Run these from a Rails console or a rake task inside your app.
+
+### Full Extraction
+
+```ruby
+# Extract everything — all 34 extractors run, output written to configured dir
+result = CodebaseIndex.extract!
+
+# Override output directory
+result = CodebaseIndex.extract!(output_dir: Rails.root.join("tmp/custom_index"))
+```
+
+### Incremental Extraction
+
+```ruby
+# Only re-extract units whose files changed
+changed = %w[app/models/order.rb app/services/checkout_service.rb]
+re_extracted = CodebaseIndex.extract_changed!(changed)
+# => ["Order", "CheckoutService"]
+```
+
+---
+
+## Reading Extraction Output with IndexReader
+
+`IndexReader` reads the JSON files produced by extraction. It does **not** require Rails — it works anywhere that can read the output directory.
+
+```ruby
+require 'codebase_index/mcp/index_reader'
+
+reader = CodebaseIndex::MCP::IndexReader.new("/path/to/tmp/codebase_index")
+```
+
+### Manifest and Summary
+
+```ruby
+reader.manifest
+# => {
+#   "extracted_at" => "2025-03-01T14:30:00Z",
+#   "git_sha" => "abc1234",
+#   "unit_counts" => { "model" => 42, "controller" => 18, "service" => 25, ... },
+#   "total_units" => 210
+# }
+
+reader.summary
+# => "# Codebase Summary\n\n42 models, 18 controllers, 25 services..."
+```
+
+---
+
+## Listing All Models with Schema
+
+```ruby
+models = reader.list_units(type: "model")
+# => [
+#   { "identifier" => "User", "file_path" => "app/models/user.rb" },
+#   { "identifier" => "Order", "file_path" => "app/models/order.rb" },
+#   ...
+# ]
+
+# Get full details for each model (includes schema, associations, callbacks)
+models.each do |entry|
+  unit = reader.find_unit(entry["identifier"])
+  puts "#{unit['identifier']}:"
+  puts "  Columns: #{unit.dig('metadata', 'columns')&.map { |c| c['name'] }&.join(', ')}"
+  puts "  Associations: #{unit.dig('metadata', 'associations')&.map { |a| "#{a['type']} :#{a['name']}" }&.join(', ')}"
+end
+# Output:
+#   User:
+#     Columns: id, email, name, created_at, updated_at
+#     Associations: has_many :orders, has_many :comments
+#   Order:
+#     Columns: id, user_id, status, total_cents, created_at, updated_at
+#     Associations: belongs_to :user, has_many :line_items
+```
+
+---
+
+## Extracting a Single Model with Inlined Concerns
+
+```ruby
+unit = reader.find_unit("Order")
+
+# Full source with concerns inlined and schema prepended
+puts unit["source_code"]
+# => "# == Schema Information\n# id :bigint not null, pk\n# user_id :bigint\n# status :string\n# total_cents :integer\n#\nclass Order < ApplicationRecord\n  include Auditable\n  belongs_to :user\n  has_many :line_items\n  ...\nend\n\n# --- Concern: Auditable ---\nmodule Auditable\n  extend ActiveSupport::Concern\n  included do\n    before_save :set_audit_trail\n  end\n  ...\nend"
+
+# Structured metadata
+unit["metadata"]["associations"]
+# => [
+#   { "type" => "belongs_to", "name" => "user", "model" => "User" },
+#   { "type" => "has_many", "name" => "line_items", "model" => "LineItem" }
+# ]
+
+unit["metadata"]["callbacks"]
+# => [
+#   {
+#     "type" => "after_commit",
+#     "method" => "send_confirmation_email",
+#     "on" => ["create"],
+#     "side_effects" => { "jobs_enqueued" => ["OrderConfirmationJob"], "services_called" => [] }
+#   }
+# ]
+
+unit["metadata"]["validations"]
+# => [
+#   { "attribute" => "status", "kind" => "inclusion", "in" => ["pending", "paid", "shipped"] },
+#   { "attribute" => "total_cents", "kind" => "numericality", "greater_than" => 0 }
+# ]
+
+unit["metadata"]["inlined_concerns"]
+# => ["Auditable"]
+```
+
+---
+
+## Listing Routes and Controller Actions
+
+```ruby
+# All routes
+routes = reader.list_units(type: "route")
+routes.each do |entry|
+  unit = reader.find_unit(entry["identifier"])
+  meta = unit["metadata"]
+  puts "#{entry['identifier']}  =>  #{meta['controller']}##{meta['action']}"
+end
+# Output:
+#   GET /orders       =>  orders#index
+#   POST /orders      =>  orders#create
+#   GET /orders/:id   =>  orders#show
+#   PATCH /orders/:id =>  orders#update
+
+# Controller with full action metadata
+ctrl = reader.find_unit("OrdersController")
+ctrl["metadata"]["actions"]     # => ["index", "show", "create", "update"]
+ctrl["metadata"]["routes"]
+# => [
+#   { "verb" => "GET", "path" => "/orders", "action" => "index" },
+#   { "verb" => "POST", "path" => "/orders", "action" => "create" },
+#   ...
+# ]
+ctrl["metadata"]["filters"]
+# => {
+#   "before" => ["authenticate_user!", "set_order"],
+#   "after" => ["track_event"]
+# }
+```
+
+---
+
+## Querying the Dependency Graph
+
+The `DependencyGraph` tracks bidirectional relationships between all units and computes PageRank importance scores.
+
+### Using IndexReader (from extraction output)
+
+```ruby
+# BFS traversal of forward dependencies
+tree = reader.traverse_dependencies("Order", depth: 2)
+# => {
+#   root: "Order",
+#   found: true,
+#   nodes: {
+#     "Order" => { type: "model", depth: 0, deps: ["User", "LineItem"] },
+#     "User" => { type: "model", depth: 1, deps: ["Account"] },
+#     "LineItem" => { type: "model", depth: 1, deps: ["Product"] }
+#   }
+# }
+
+# BFS traversal of reverse dependencies (what depends on Order?)
+dependents = reader.traverse_dependents("Order", depth: 2, types: ["controller", "service"])
+# => {
+#   root: "Order",
+#   found: true,
+#   nodes: {
+#     "Order" => { type: "model", depth: 0, deps: ["OrdersController", "CheckoutService"] },
+#     "OrdersController" => { type: "controller", depth: 1, deps: [] },
+#     "CheckoutService" => { type: "service", depth: 1, deps: ["OrderMailer"] }
+#   }
+# }
+```
+
+### Using DependencyGraph Directly (in-process, requires Rails)
+
+```ruby
+graph = CodebaseIndex::DependencyGraph.new
+
+# Register units (normally done by the Extractor)
+graph.register(user_unit)
+graph.register(order_unit)
+
+# Direct queries
+graph.dependencies_of("Order")   # => ["User", "LineItem"]
+graph.dependents_of("User")      # => ["Order", "Comment", "UsersController"]
+graph.units_of_type(:model)      # => ["User", "Order", "LineItem", "Comment", ...]
+
+# Blast radius: what's affected by a file change?
+graph.affected_by(["app/models/user.rb"])
+# => ["User", "Order", "UsersController", "ProfileService", ...]
+
+# PageRank importance scores
+scores = graph.pagerank
+scores.sort_by { |_, v| -v }.first(5).each do |id, score|
+  puts "#{id}: #{score.round(4)}"
+end
+# Output:
+#   User: 0.0842
+#   Order: 0.0631
+#   Product: 0.0523
+#   Account: 0.0412
+#   LineItem: 0.0389
+```
+
+---
+
+## Accessing Framework and Gem Source
+
+`RailsSourceExtractor` indexes high-value Rails framework source and gem source files, pinned to the exact versions in your `Gemfile.lock`.
+
+```ruby
+# Search indexed framework source by keyword
+results = reader.framework_sources("has_many", limit: 5)
+# => [
+#   {
+#     identifier: "ActiveRecord::Associations::ClassMethods",
+#     type: "rails_source",
+#     file_path: "/path/to/gems/activerecord-7.2.0/lib/active_record/associations.rb",
+#     metadata: { "gem" => "activerecord", "version" => "7.2.0" }
+#   },
+#   ...
+# ]
+
+# Get the full source of a framework unit
+unit = reader.find_unit("ActiveRecord::Associations::ClassMethods")
+puts unit["source_code"]  # => actual Rails source for has_many, belongs_to, etc.
+```
+
+### Configuring Additional Gems
+
+```ruby
+# config/initializers/codebase_index.rb
+CodebaseIndex.configure do |config|
+  config.add_gem "devise", paths: ["lib/devise/models"], priority: :high
+  config.add_gem "pundit", paths: ["lib/pundit"], priority: :medium
+end
+```
+
+After extraction, these gems appear as `rails_source` type units searchable via `framework_sources`.
+
+---
+
+## Git Enrichment Data
+
+Every unit with a file path gets git metadata after extraction. The `metadata.git` hash contains:
+
+```ruby
+unit = reader.find_unit("Order")
+git = unit.dig("metadata", "git")
+# => {
+#   "last_modified" => "2025-02-15T10:22:00Z",
+#   "last_author" => "Alice",
+#   "commit_count" => 47,
+#   "change_frequency" => "hot",
+#   "contributors" => [
+#     { "name" => "Alice", "commits" => 22 },
+#     { "name" => "Bob", "commits" => 15 },
+#     { "name" => "Carol", "commits" => 10 }
+#   ],
+#   "recent_commits" => [
+#     { "sha" => "abc1234", "message" => "Add status validation", "date" => "2025-02-15", "author" => "Alice" },
+#     { "sha" => "def5678", "message" => "Fix total calculation", "date" => "2025-02-10", "author" => "Bob" },
+#     ...
+#   ]
+# }
+```
+
+### Finding Recently Changed Code
+
+```ruby
+# Most recently modified units (useful for code review or onboarding)
+changes = reader.recent_changes(limit: 10, types: ["model", "service"])
+changes.each do |c|
+  puts "#{c[:identifier]} (#{c[:type]}) — last modified #{c[:last_modified]}"
+end
+# Output:
+#   Order (model) — last modified 2025-02-15T10:22:00Z
+#   CheckoutService (service) — last modified 2025-02-14T09:15:00Z
+#   User (model) — last modified 2025-02-10T16:45:00Z
+#   ...
+```
+
+### Change Frequency Categories
+
+| Frequency | Meaning |
+|-----------|---------|
+| `new` | Created in the last 30 days |
+| `hot` | 10+ commits in the last 90 days |
+| `active` | 3-9 commits in the last 90 days |
+| `stable` | 1-2 commits in the last 90 days |
+| `dormant` | No commits in the last 90 days |
+
+---
+
+## Controller Action Context
+
+Combine unit lookup with dependency traversal to build full context for a controller action:
+
+```ruby
+# 1. Get the controller
+ctrl = reader.find_unit("OrdersController")
+
+# 2. Get its dependencies (services, models it touches)
+deps = reader.traverse_dependencies("OrdersController", depth: 2)
+
+# 3. Collect all related units
+context_units = deps[:nodes].keys.map { |id| reader.find_unit(id) }.compact
+
+# 4. Now you have: controller source + all models/services/jobs it touches
+context_units.each do |u|
+  puts "#{u['identifier']} (#{u['type']}): #{u['source_code']&.lines&.count} lines"
+end
+# Output:
+#   OrdersController (controller): 85 lines
+#   Order (model): 120 lines
+#   User (model): 95 lines
+#   CheckoutService (service): 60 lines
+#   OrderConfirmationJob (job): 25 lines
+```
+
+---
+
+## Runtime Introspection Output
+
+CodebaseIndex uses runtime introspection to capture data that static analysis cannot. Here's what that looks like in practice.
+
+### Callbacks with Side Effects
+
+```ruby
+unit = reader.find_unit("Order")
+unit["metadata"]["callbacks"]
+# => [
+#   {
+#     "type" => "before_save",
+#     "method" => "normalize_status",
+#     "side_effects" => { "columns_written" => ["status", "normalized_at"], "jobs_enqueued" => [], "services_called" => [] }
+#   },
+#   {
+#     "type" => "after_commit",
+#     "method" => "send_confirmation_email",
+#     "on" => ["create"],
+#     "side_effects" => { "columns_written" => [], "jobs_enqueued" => ["OrderConfirmationJob"], "services_called" => [] }
+#   },
+#   {
+#     "type" => "after_commit",
+#     "method" => "sync_to_warehouse",
+#     "on" => ["update"],
+#     "side_effects" => { "columns_written" => [], "jobs_enqueued" => [], "services_called" => ["WarehouseSync"] }
+#   }
+# ]
+```
+
+### Associations with Reflection Data
+
+```ruby
+unit["metadata"]["associations"]
+# => [
+#   { "type" => "belongs_to", "name" => "user", "model" => "User", "foreign_key" => "user_id", "optional" => false },
+#   { "type" => "has_many", "name" => "line_items", "model" => "LineItem", "foreign_key" => "order_id", "dependent" => "destroy" },
+#   { "type" => "has_one", "name" => "invoice", "model" => "Invoice", "foreign_key" => "order_id" }
+# ]
+```
+
+### Validations
+
+```ruby
+unit["metadata"]["validations"]
+# => [
+#   { "attribute" => "status", "kind" => "inclusion", "in" => ["pending", "paid", "shipped", "cancelled"] },
+#   { "attribute" => "total_cents", "kind" => "numericality", "greater_than" => 0 },
+#   { "attribute" => "user", "kind" => "presence" }
+# ]
+```
+
+---
+
+## Retrieval Pipeline
+
+The retrieval pipeline provides semantic search over extracted units. It requires an embedding provider to be configured.
+
+### Configuration
+
+```ruby
+CodebaseIndex.configure do |config|
+  config.embedding_provider = :openai
+  config.embedding_options = { api_key: ENV["OPENAI_API_KEY"] }
+  config.vector_store = :pgvector   # or :qdrant, :sqlite
+  config.metadata_store = :postgresql  # or :mysql, :sqlite
+end
+```
+
+### Querying
+
+```ruby
+result = CodebaseIndex.retrieve("How does order checkout work?")
+
+result.context       # => formatted context string with relevant source code
+result.sources       # => [{ identifier: "CheckoutService", type: "service", score: 0.92 }, ...]
+result.strategy      # => :hybrid (or :vector, :keyword, :graph)
+result.tokens_used   # => 4200
+result.budget        # => 8000
+result.classification # => { intent: :explanation, scope: :specific, target_type: "service" }
+
+# Custom token budget
+result = CodebaseIndex.retrieve("user authentication flow", budget: 12000)
+```
+
+### Building a Retriever Directly
+
+```ruby
+retriever = CodebaseIndex.build_retriever
+
+# Multiple queries with the same retriever instance
+r1 = retriever.retrieve("payment processing")
+r2 = retriever.retrieve("user permissions", budget: 4000)
+```
+
+---
+
+## Search
+
+```ruby
+# Search by identifier (fast — index-only)
+reader.search("Order", types: ["model", "service"], limit: 10)
+# => [
+#   { identifier: "Order", type: "model", match_field: "identifier" },
+#   { identifier: "OrderService", type: "service", match_field: "identifier" }
+# ]
+
+# Search across source code (slower — loads unit files)
+reader.search("perform_later", fields: ["source_code"], types: ["model"], limit: 5)
+# => [
+#   { identifier: "Order", type: "model", match_field: "source_code" },
+#   { identifier: "User", type: "model", match_field: "source_code" }
+# ]
+```
+
+---
+
+## Graph Analysis
+
+The extraction output includes `graph_analysis.json` with pre-computed structural insights:
+
+```ruby
+analysis = reader.graph_analysis
+# => {
+#   "orphans" => ["LegacyImporter", "UnusedHelper"],
+#   "dead_ends" => ["EmailValidator", "CurrencyFormatter"],
+#   "hubs" => [
+#     { "identifier" => "User", "dependents_count" => 34 },
+#     { "identifier" => "Order", "dependents_count" => 22 }
+#   ],
+#   "cycles" => [
+#     ["Order", "LineItem", "Product", "Order"]
+#   ],
+#   "bridges" => ["AuthenticationService", "BaseController"]
+# }
+```


### PR DESCRIPTION
## Summary

- **New `docs/RUBY_API_GUIDE.md`** — 483-line guide with 22 executable Ruby code blocks covering programmatic extraction, IndexReader queries, DependencyGraph traversal, git enrichment, retrieval pipeline, and runtime introspection output
- **Enriched `docs/MCP_TOOL_COOKBOOK.md`** — added concrete JSON response bodies for `structure`, `lookup`, `dependents`, and `framework` tools
- **Enriched `docs/EXTRACTOR_REFERENCE.md`** — added RailsSourceExtractor output example and full git enrichment JSON
- **Updated `context7.json`** — added `$schema`, `projectTitle`, `description`, and 4 `rules` for better Context7 indexing
- **Updated `docs/README.md`** — added RUBY_API_GUIDE.md to the User Guides index

## Test plan

- [x] `context7.json` validates as valid JSON
- [ ] Trigger Context7 refresh on admin panel to re-index docs
- [ ] Re-run Context7 benchmark to measure score improvement (target: 59.7 → 80+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)